### PR TITLE
Improve error messages and how errors are detected

### DIFF
--- a/kidiff/kidiff.py
+++ b/kidiff/kidiff.py
@@ -93,13 +93,13 @@ def get_project_scms(repo_path):
 
     if is_tool_available("git"):
         cmd = ["git", "status"]
-        stdout, stderr = settings.run_cmd(repo_path, cmd)
+        stdout, stderr, _ret = settings.run_cmd(repo_path, cmd)
         if (stdout != "") & (stderr == ""):
             scms.append("git")
 
     if is_tool_available("fossil"):
         cmd = ["fossil", "status"]
-        stdout, stderr = settings.run_cmd(repo_path, cmd)
+        stdout, stderr, _ret = settings.run_cmd(repo_path, cmd)
         if stdout != "":
             scms.append("fossil")
 
@@ -108,7 +108,7 @@ def get_project_scms(repo_path):
             "svn",
             "log",
         ]  # | perl -l4svn log0pe "s/^-+/\n/"'.format(repo_path=repo_path)
-        stdout, stderr = settings.run_cmd(repo_path, cmd)
+        stdout, stderr, _ret = settings.run_cmd(repo_path, cmd)
         if (stdout != "") & (stderr == ""):
             scms.append("svn")
 
@@ -158,21 +158,17 @@ def pcb_to_svg(kicad_pcb_path, repo_path, kicad_project_dir, board_filename, com
         plot1_cmd.append("-n")
         plot2_cmd.append("-n")
 
-    stdout, stderr = settings.run_cmd(commit1_output_path, plot1_cmd)
-    plot1_stdout = stdout
-    plot1_stderr = stderr
+    plot1_stdout, plot1_stderr, plot1_ret = settings.run_cmd(commit1_output_path, plot1_cmd)
 
     if plot1_stderr != "":
-        print(plot1_stderr)
+        print(plot1_stderr, file=sys.stderr)
 
-    stdout, stderr = settings.run_cmd(commit2_output_path, plot2_cmd)
-    plot2_stdout = stdout
-    plot2_stderr = stderr
+    plot2_stdout, plot2_stderr, plot2_ret = settings.run_cmd(commit2_output_path, plot2_cmd)
 
     if plot2_stderr != "":
-        print(plot2_stderr)
+        print(plot2_stderr, file=sys.stderr)
 
-    if not plot1_stdout or not plot2_stdout:
+    if not plot1_stdout or not plot2_stdout or plot1_ret != 0 or plot2_ret != 0:
         print("Error while plotting the layout with {}".format(settings.pcb_plot_prog))
         exit(1)
 
@@ -224,21 +220,17 @@ def sch_to_svg(kicad_sch_path, repo_path, kicad_project_dir, page_filename, comm
         print("cd", commit1_output_path + ";", ' '.join(map(str, plot1_cmd)))
         print("cd", commit2_output_path + ";", ' '.join(map(str, plot2_cmd)))
 
-    stdout, stderr = settings.run_cmd(commit1_output_path, plot1_cmd)
-    plot1_stdout = stdout
-    plot1_stderr = stderr
+    plot1_stdout, plot1_stderr, plot1_ret = settings.run_cmd(commit1_output_path, plot1_cmd)
 
     if plot1_stderr != "":
-        print(plot1_stderr)
+        print(plot1_stderr, file=sys.stderr)
 
-    stdout, stderr = settings.run_cmd(commit2_output_path, plot2_cmd)
-    plot2_stdout = stdout
-    plot2_stderr = stderr
+    plot2_stdout, plot2_stderr, plot2_ret = settings.run_cmd(commit2_output_path, plot2_cmd)
 
     if plot2_stderr != "":
-        print(plot2_stderr)
+        print(plot2_stderr, file=sys.stderr)
 
-    if not plot1_stdout or not plot2_stdout:
+    if not plot1_stdout or not plot2_stdout or plot1_ret != 0 or plot2_ret != 0:
         print("Error while ploting schematics with {}".format(settings.sch_plot_prog))
         # exit(1)
 
@@ -514,7 +506,7 @@ def assemble_html(kicad_pcb_path, repo_path, kicad_project_dir, board_filename, 
     board2_path = os.path.join(output_dir2, board_filename)
     diff_path   = os.path.join(settings.output_dir, "diff.txt")
 
-    stdout, stderr = settings.run_cmd(settings.output_dir, [settings.diffProg, board2_path, board1_path])
+    stdout, _stderr, _ret = settings.run_cmd(settings.output_dir, [settings.diffProg, board2_path, board1_path])
 
     with open(diff_path, "a") as fout:
         fout.write(stdout)

--- a/kidiff/plot_kicad_pcb.py
+++ b/kidiff/plot_kicad_pcb.py
@@ -51,9 +51,11 @@ def processBoard(board_path, plot_dir, quiet=1, verbose=0, plot_frame=0, id_only
         # LoadBoard gives me this
         # ../src/common/stdpbase.cpp(62): assert "traits" failed in Get(): create wxApp before calling this
         board = pn.LoadBoard(board_path)
-    except:
-        print("Wrong version of the API")
-        print("Try sourcing 'env-nightly.sh' instead.")
+    except Exception as e:
+        print(f"Error when trying to load board at '{board_path}'", file=sys.stderr)
+        print(e, file=sys.stderr)
+        print("Wrong version of the API", file=sys.stderr)
+        print("Try sourcing 'env-nightly.sh' instead.", file=sys.stderr)
         exit(1)
 
     print("")

--- a/kidiff/scms/fossil.py
+++ b/kidiff/scms/fossil.py
@@ -33,7 +33,7 @@ class scm(generic_scm):
 
             cmd = ["fossil", "diff", "--brief", "-r", artifact1, "--to", artifact2]
 
-            stdout, stderr = settings.run_cmd(repo_path, cmd)
+            stdout, _stderr, _ret = settings.run_cmd(repo_path, cmd)
             changed = ".kicad_pcb" in stdout
 
             if not changed:
@@ -89,10 +89,10 @@ class scm(generic_scm):
             timeDiff2 = time.strftime("%H:%M:%S", time.localtime(modTimesinceEpoc))
 
         if not commit1 == board_filename:
-            stdout, stderr = settings.run_cmd(repo_path, fossilArtifact1)
+            stdout, _stderr, _ret = settings.run_cmd(repo_path, fossilArtifact1)
             with open(os.path.join(outputDir1, board_filename), "w") as f:
                 f.write(stdout)
-            dateTime, _ = settings.run_cmd(repo_path, fossilDateTime1)
+            dateTime, _stderr, _ret = settings.run_cmd(repo_path, fossilDateTime1)
             (
                 uuid,
                 _,
@@ -112,10 +112,10 @@ class scm(generic_scm):
             shutil.copyfile(kicad_pcb_path, os.path.join(outputDir1, board_filename))
 
         if not commit2 == board_filename:
-            stdout, stderr = settings.run_cmd(repo_path, fossilArtifact2)
+            stdout, _stderr, _ret = settings.run_cmd(repo_path, fossilArtifact2)
             with open(os.path.join(outputDir2, board_filename), "w") as f:
                 f.write(stdout)
-            dateTime, _ = settings.run_cmd(repo_path, fossilDateTime2)
+            dateTime, _stderr, _ret = settings.run_cmd(repo_path, fossilDateTime2)
             (
                 uuid,
                 _,
@@ -144,7 +144,7 @@ class scm(generic_scm):
 
         cmd = ["fossil", "finfo", "-b", os.path.join(kicad_project_dir, board_filename)]
 
-        stdout, stderr = settings.run_cmd(repo_path, cmd)
+        stdout, _stderr, _ret = settings.run_cmd(repo_path, cmd)
         artifacts = [board_filename] + [
             a.replace(" ", " | ", 4) for a in stdout.splitlines()
         ]
@@ -157,7 +157,7 @@ class scm(generic_scm):
 
         cmd = ["fossil", "status"]
 
-        stdout, _ = settings.run_cmd(kicad_project_path, cmd)
+        stdout, _stderr, _ret = settings.run_cmd(kicad_project_path, cmd)
         repo_path = stdout.split()[3]
 
         kicad_project_dir = os.path.relpath(kicad_project_path, repo_path)

--- a/kidiff/scms/git.py
+++ b/kidiff/scms/git.py
@@ -39,7 +39,7 @@ class scm(generic_scm):
         if (not commit1 == board_filename) and (not commit2 == board_filename):
             cmd = ["git", "diff", "--name-only", artifact1, artifact2, "."]
 
-            stdout, stderr = settings.run_cmd(repo_path, cmd)
+            stdout, _stderr, _ret = settings.run_cmd(repo_path, cmd)
             changed = (prj_path + board_filename) in stdout
 
             if not changed:
@@ -68,14 +68,14 @@ class scm(generic_scm):
             gitArtifact2 = ["git", "show", artifact2 + ":" + board_subpath]
 
         if not commit1 == board_filename:
-            stdout, stderr = settings.run_cmd(repo_path, gitArtifact1)
+            stdout, _stderr, _ret = settings.run_cmd(repo_path, gitArtifact1)
             with open(os.path.join(outputDir1, board_filename), "w") as fout1:
                 fout1.write(stdout)
         else:
             shutil.copyfile(kicad_pcb_path, os.path.join(outputDir1, board_filename))
 
         if not commit2 == board_filename:
-            stdout, stderr = settings.run_cmd(repo_path, gitArtifact2)
+            stdout, _stderr, _ret = settings.run_cmd(repo_path, gitArtifact2)
             with open(os.path.join(outputDir2, board_filename), "w") as fout2:
                 fout2.write(stdout)
         else:
@@ -88,7 +88,7 @@ class scm(generic_scm):
             gitDateTime2 = ["git", "show", "-s", '--format="%ci"', artifact2]
 
         if not commit1 == board_filename:
-            stdout, stderr = settings.run_cmd(repo_path, gitDateTime1)
+            stdout, _stderr, _ret = settings.run_cmd(repo_path, gitDateTime1)
             dateTime1 = stdout
             date1, time1, UTC = dateTime1.split(" ")
             time1 = date1 + " " + time1
@@ -98,7 +98,7 @@ class scm(generic_scm):
             time1 = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(modTimesinceEpoc))
 
         if not commit2 == board_filename:
-            stdout, stderr = settings.run_cmd(repo_path, gitDateTime2)
+            stdout, _stderr, _ret = settings.run_cmd(repo_path, gitDateTime2)
             dateTime2 = stdout
             date2, time2, UTC = dateTime2.split(" ")
             time2 = date2 + " " + time2
@@ -140,7 +140,7 @@ class scm(generic_scm):
         if (not commit1 == page_filename) and (not commit2 == page_filename):
             cmd = ["git", "diff", "--name-only", artifact1, artifact2, "."]
 
-            stdout, stderr = settings.run_cmd(repo_path, cmd)
+            stdout, _stderr, _ret = settings.run_cmd(repo_path, cmd)
             changed = (prj_path + page_filename) in stdout
 
             if not changed:
@@ -168,14 +168,14 @@ class scm(generic_scm):
             gitArtifact2 = ["git", "show", artifact2 + ":" + page_subpath]
 
         if not commit1 == page_filename:
-            stdout, stderr = settings.run_cmd(repo_path, gitArtifact1)
+            stdout, _stderr, _ret = settings.run_cmd(repo_path, gitArtifact1)
             with open(os.path.join(outputDir1, page_filename), "w") as fout1:
                 fout1.write(stdout)
         else:
             shutil.copyfile(kicad_sch_path, os.path.join(outputDir1, page_filename))
 
         if not commit2 == page_filename:
-            stdout, stderr = settings.run_cmd(repo_path, gitArtifact2)
+            stdout, _stderr, _ret = settings.run_cmd(repo_path, gitArtifact2)
             with open(os.path.join(outputDir2, page_filename), "w") as fout2:
                 fout2.write(stdout)
         else:
@@ -188,11 +188,11 @@ class scm(generic_scm):
             gitDateTime2 = ["git", "show", "-s", '--format="%ci"', artifact2]
 
         if not commit1 == page_filename:
-            stdout, stderr = settings.run_cmd(repo_path, gitDateTime1)
+            stdout, _stderr, _ret = settings.run_cmd(repo_path, gitDateTime1)
             # print(stdout)
 
         if not commit2 == page_filename:
-            stdout, stderr = settings.run_cmd(repo_path, gitDateTime2)
+            stdout, _stderr, _ret = settings.run_cmd(repo_path, gitDateTime2)
             # print(stdout)
 
     @staticmethod
@@ -200,7 +200,7 @@ class scm(generic_scm):
         """Returns list of artifacts from a directory"""
 
         cmd = ["git", "log", "--date=format-local:%Y-%m-%d %H:%M:%S", "--pretty=format:%h | %ad | %an | %s", os.path.join(kicad_project_dir, board_file)]
-        stdout, _ = settings.run_cmd(repo_path, cmd)
+        stdout, _stderr, _ret = settings.run_cmd(repo_path, cmd)
         artifacts = ["local"] + stdout.splitlines()
 
         return artifacts
@@ -211,7 +211,7 @@ class scm(generic_scm):
 
         cmd = ["git", "rev-parse", "--show-toplevel"]
 
-        stdout, _ = settings.run_cmd(kicad_project_path, cmd)
+        stdout, _stderr, _ret = settings.run_cmd(kicad_project_path, cmd)
         repo_path = stdout.strip()
 
         kicad_project_dir = os.path.relpath(kicad_project_path, repo_path)

--- a/kidiff/scms/svn.py
+++ b/kidiff/scms/svn.py
@@ -33,7 +33,7 @@ class scm(generic_scm):
         if (not commit1 == board_filename) and (not commit2 == board_filename):
             cmd = ["svn", "diff", "--summarize", "-r", artifact1 + ":" + artifact2, prj_path + board_filename,]
 
-            stdout, stderr = settings.run_cmd(repo_path, cmd)
+            stdout, _stderr, _ret = settings.run_cmd(repo_path, cmd)
             changed, *boardName = stdout
 
             if changed != "M":
@@ -60,14 +60,14 @@ class scm(generic_scm):
             svnArtifact2 = ["svn", "cat", "-r", artifact2, board_subpath]
 
         if not commit1 == board_filename:
-            stdout, stderr = settings.run_cmd(repo_path, svnArtifact1)
+            stdout, _stderr, _ret = settings.run_cmd(repo_path, svnArtifact1)
             with open(os.path.join(outputDir1, board_filename), "w") as fout1:
                 fout1.write(stdout)
         else:
             shutil.copyfile(kicad_pcb_path, os.path.join(outputDir1, board_filename))
 
         if not commit2 == board_filename:
-            stdout, stderr = settings.run_cmd(repo_path, svnArtifact2)
+            stdout, _stderr, _ret = settings.run_cmd(repo_path, svnArtifact2)
             with open(os.path.join(outputDir2, board_filename), "w") as fout2:
                 fout2.write(stdout)
         else:
@@ -80,7 +80,7 @@ class scm(generic_scm):
             svnDateTime2 = ["svn", "log", "-r", artifact2]
 
         if not commit1 == board_filename:
-            stdout, stderr = settings.run_cmd(repo_path, svnDateTime1)
+            stdout, _stderr, _ret = settings.run_cmd(repo_path, svnDateTime1)
             dateTime = stdout
             cmt = (dateTime.splitlines()[1]).split("|")
             _, SVNdate1, SVNtime1, SVNutc, *_ = cmt[2].split(" ")
@@ -93,7 +93,7 @@ class scm(generic_scm):
         time1 = SVNdate1 + " " + SVNtime1
 
         if not commit2 == board_filename:
-            stdout, stderr = settings.run_cmd(repo_path, svnDateTime2)
+            stdout, _stderr, _ret = settings.run_cmd(repo_path, svnDateTime2)
             dateTime = stdout
 
             cmt = (dateTime.splitlines()[1]).split("|")
@@ -113,7 +113,7 @@ class scm(generic_scm):
         """Returns list of revisions from a directory"""
 
         cmd = ["svn", "log", "--xml", "-r", "HEAD:0", os.path.join(kicad_project_dir, board_filename)]
-        stdout, _ = settings.run_cmd(repo_path, cmd)
+        stdout, _stderr, _ret = settings.run_cmd(repo_path, cmd)
 
         root = et.fromstring(stdout)
         commits = []
@@ -140,7 +140,7 @@ class scm(generic_scm):
         """Returns the root folder of the repository"""
 
         cmd = ["svn", "info", "--show-item", "wc-root"]
-        stdout, _ = settings.run_cmd(kicad_project_path, cmd)
+        stdout, _stderr, _ret = settings.run_cmd(kicad_project_path, cmd)
         repo_path = stdout.strip()
 
         kicad_project_dir = os.path.relpath(kicad_project_path, repo_path)

--- a/kidiff/settings.py
+++ b/kidiff/settings.py
@@ -45,7 +45,7 @@ class bcolors:
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
 
-def run_cmd(exec_path: str, cmd: List[str]) -> Tuple[str, str]:
+def run_cmd(exec_path: str, cmd: List[str]) -> Tuple[str, str, int]:
 
     if verbose > 1:
         print("")
@@ -78,4 +78,4 @@ def run_cmd(exec_path: str, cmd: List[str]) -> Tuple[str, str]:
             print(bcolors.FAIL + "Code:", str(ret) + bcolors.ENDC)
 
 
-    return stdout.strip("\n "), stderr
+    return stdout.strip("\n "), stderr, ret


### PR DESCRIPTION
- In `kidiff.py`, check the subproccess exit code, not just whether it printed on stdout
- In `plot_kicad_pcb.py`, print errors on stderr, not stdout, and actually print the python error so that it's possible to see what went wrong