### PR TITLE
Fix for filenames with dots

### DIFF
--- a/kidiff/kidiff.py
+++ b/kidiff/kidiff.py
@@ -1030,11 +1030,11 @@ if __name__ == "__main__":
     # page_filename = board_filename.replace(".kicad_pcb", ".kicad_sch")
 
     if ".kicad_" in extension:
-        page_filename = board_filename.split(".")[0] + ".kicad_sch"
+        page_filename = f"{os.path.splitext(os.path.basename(board_filename))[0]}.kicad_sch"
     else:
-        page_filename = board_filename.split(".")[0] + ".sch"
+        page_filename = f"{os.path.splitext(os.path.basename(board_filename))[0]}.sch"
 
-    board_filename = board_filename.split(".")[0] + ".kicad_pcb"
+    board_filename = f"{os.path.splitext(os.path.basename(board_filename))[0]}.kicad_pcb"
 
     if export_mode == "sch" or export_mode == "all":
         _, _, _ = scm.get_pages(kicad_sch_path, repo_path, kicad_project_dir, page_filename, commit1, commit2)


### PR DESCRIPTION
If the filename contains more than one dot, e.g. name_1.2.kicad_pro, the script fails.